### PR TITLE
Rename namespaces and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,21 @@
 
 > Re-frame extensions
 
-[![CircleCI](https://circleci.com/gh/vimsical/re-frame-utils.svg?style=svg)](https://circleci.com/gh/vimsical/re-frame-utils)
-
-[![Clojars Project](https://img.shields.io/clojars/v/re-frame-utils.svg)](https://clojars.org/re-frame-utils)
-
+Pipo Saúde's fork of the currently unmantained [re-frame-utils](https://github.com/den1k/re-frame-utils).
 
 ## Releases and Dependency Information
 
-* [All releases](https://clojars.org/vimsical/re-frame-utils)
+Add it to `deps.edn` (check for latest release tag and sha)
 
-[Leiningen] dependency information:
-
-    [vimsical/re-frame-utils "0.1.0"]
-
-[Maven] dependency information:
-
-    <dependency>
-      <groupId>vimsical</groupId>
-      <artifactId>re-frame-utils</artifactId>
-      <version>0.1.0</version>
-    </dependency>
-
-[Gradle] dependency information:
-
-    compile "vimsical:re-frame-utils:0.1.0"
-
-[Clojars]: http://clojars.org/
-[Leiningen]: http://leiningen.org/
-[Maven]: http://maven.apache.org/
-[Gradle]: http://www.gradle.org/
-
+``` clojure
+io.github.piposaude/re-frame-utils {:git/tag "0.2.0"
+                                    :git/sha "05f5144481d04856520fc2cd672d6bb9c798fe48"}
+```
 
 
 ## Dependencies and Compatibility
 
-Tested against `re-frame 0.9.4` and `clojurescript 1.9.671`.
+Tested against `re-frame 1.3.0` and `clojurescript 1.10.773`.
 
 
 
@@ -48,7 +28,7 @@ Tested against `re-frame 0.9.4` and `clojurescript 1.9.671`.
 
 
 
-#### [Inject](./src/vimsical/re_frame/cofx/inject.cljc)
+#### [Inject](./src/com/piposaude/re_frame/cofx/inject.cljc)
 
 Inject a subscription in an event handler.
 
@@ -58,7 +38,7 @@ Inject a subscription in an event handler.
 
 
 
-#### [Track](./src/vimsical/re_frame/fx/track.cljc)
+#### [Track](./src/com/piposaude/re_frame/fx/track.cljc)
 
 Dynamically dispatch events when subscriptions update.
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,8 +3,8 @@
  :nrepl    {:port 11011}
  :builds   {:lib  {:target      :browser
                    :output-dir  "public/js"
-                   :modules     {:main {:entries [vimsical.re-frame.cofx.inject
-                                                  vimsical.re-frame.fx.track]}}
+                   :modules     {:main {:entries [com.piposaude.re-frame.cofx.inject
+                                                  com.piposaude.re-frame.fx.track]}}
                    :profile     :dev}
             :test {:target      :karma
                    :output-to   "out/karma_tests.js"

--- a/src/com/piposaude/re_frame/cofx/inject.cljc
+++ b/src/com/piposaude/re_frame/cofx/inject.cljc
@@ -1,4 +1,4 @@
-(ns vimsical.re-frame.cofx.inject
+(ns com.piposaude.re-frame.cofx.inject
   "Inject a subscription in an event handler.
 
   *** Performance caveat ***
@@ -57,7 +57,7 @@
 
   Examples:
 
-  (require '[vimsical.re-frame.cofx.inject :as inject])
+  (require '[com.piposaude.re-frame.cofx.inject :as inject])
 
   ;; Injecting a simple subscription:
 

--- a/src/com/piposaude/re_frame/fx/track.cljc
+++ b/src/com/piposaude/re_frame/fx/track.cljc
@@ -1,4 +1,4 @@
-(ns vimsical.re-frame.fx.track
+(ns com.piposaude.re-frame.fx.track
   "Dispatch events when subscriptions change.
 
   Tracking a subscription is a stateful process that needs to be registered and
@@ -17,7 +17,7 @@
 
   Usage:
 
-  (require '[vimsical.re-frame.fx.track :as track])
+  (require '[com.piposaude.re-frame.fx.track :as track])
 
   0. Context
 

--- a/test/com/piposaude/re_frame/cofx/inject_test.cljc
+++ b/test/com/piposaude/re_frame/cofx/inject_test.cljc
@@ -1,4 +1,4 @@
-(ns vimsical.re-frame.cofx.inject-test
+(ns com.piposaude.re-frame.cofx.inject-test
   "Simple test to verify subscription injection.
 
   - The app-db contains a seq of numbers.
@@ -16,11 +16,11 @@
   the sum event handler, limit gets picked up by the cofx and the value of the
   numbers sub contains a limited range of numbers."
   (:require
-   [re-frame.core :as re-frame]
-   [day8.re-frame.test :as re-frame.test]
-   [vimsical.re-frame.cofx.inject :as sut]
    #?(:clj [clojure.test :as t]
-      :cljs [cljs.test :as t :include-macros true])))
+      :cljs [cljs.test :as t :include-macros true])
+   [com.piposaude.re-frame.cofx.inject :as sut]
+   [day8.re-frame.test :as re-frame.test]
+   [re-frame.core :as re-frame]))
 
 
 (def test-db {:numbers (range 10)})

--- a/test/com/piposaude/re_frame/fx/track_test.cljs
+++ b/test/com/piposaude/re_frame/fx/track_test.cljs
@@ -1,10 +1,10 @@
-(ns vimsical.re-frame.fx.track-test
+(ns com.piposaude.re-frame.fx.track-test
   (:require
-   [reagent.core :as r]
-   [vimsical.re-frame.fx.track :as sut]
-   [day8.re-frame.test :as re-frame.test]
    [cljs.test :as t :include-macros true]
-   [re-frame.core :as re-frame]))
+   [com.piposaude.re-frame.fx.track :as sut]
+   [day8.re-frame.test :as re-frame.test]
+   [re-frame.core :as re-frame]
+   [reagent.core :as r]))
 
 
 (def test-db {:source 0 :sink nil})


### PR DESCRIPTION
- Namespaces: `vimsical` -> `com.piposaude`
- A few instructions in the readme.